### PR TITLE
Return expected format in Date header

### DIFF
--- a/lib/Http/Response.php
+++ b/lib/Http/Response.php
@@ -71,7 +71,7 @@ class Response {
         $this->setStatus(200);
         $this->setHeaders([
             'Connection'   => 'keep-alive',
-            'Date'         => date('D d M Y H:i:s e'),
+            'Date'         => gmdate('D, d M Y H:i:s T'),
             'Content-Type' => 'text/plain',
             'X-Powered-By' => 'Enginr'
         ]);


### PR DESCRIPTION
According with the [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.1.1), the date need to be returned in GMT hour and not the server date. 

See too: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date